### PR TITLE
Write a unit test for renaming fields

### DIFF
--- a/common/src/test/scala/org/broadinstitute/monster/etl/MsgTransformationsSpec.scala
+++ b/common/src/test/scala/org/broadinstitute/monster/etl/MsgTransformationsSpec.scala
@@ -23,7 +23,26 @@ class MsgTransformationsSpec extends FlatSpec with Matchers {
     )
   }
 
-  it should "continue if a field-to-rename doesn't exist in a message" in {
+  it should "continue if a field-to-rename doesn't exist" in {
+    val input = Obj(
+      Str("foo") -> Str("bar"),
+      Str("foobar") -> Int32(123),
+      Str("baz") -> Arr(Str("qux"), Float64(1.23)),
+      Str("abc") -> Int32(121)
+    )
+
+    val renamed =
+      MsgTransformations.renameFields(Map("abc" -> "xyz", "lol" -> "haha"))(input)
+
+    renamed shouldBe Obj(
+      Str("foo") -> Str("bar"),
+      Str("foobar") -> Int32(123),
+      Str("baz") -> Arr(Str("qux"), Float64(1.23)),
+      Str("xyz") -> Int32(121)
+    )
+  }
+
+  it should "continue if none of the fields-to-rename exist" in {
     val input = Obj(
       Str("foo") -> Str("bar"),
       Str("foobar") -> Int32(123),

--- a/common/src/test/scala/org/broadinstitute/monster/etl/MsgTransformationsSpec.scala
+++ b/common/src/test/scala/org/broadinstitute/monster/etl/MsgTransformationsSpec.scala
@@ -24,7 +24,20 @@ class MsgTransformationsSpec extends FlatSpec with Matchers {
   }
 
   it should "continue if a field-to-rename doesn't exist in a message" in {
-    ???
+    val input = Obj(
+      Str("foo") -> Str("bar"),
+      Str("foobar") -> Int32(123),
+      Str("baz") -> Arr(Str("qux"), Float64(1.23))
+    )
+
+    val renamed =
+      MsgTransformations.renameFields(Map("abc" -> "xyz", "lol" -> "haha"))(input)
+
+    renamed shouldBe Obj(
+      Str("foo") -> Str("bar"),
+      Str("foobar") -> Int32(123),
+      Str("baz") -> Arr(Str("qux"), Float64(1.23))
+    )
   }
 
   it should "collect object fields into an array" in {


### PR DESCRIPTION
fill out test to make sure MsgTransformations.renameFields continues, aka (passes through) the input if none of the fields in the message are mapped to a renamed field (the first test already checks the case where some of the field names should be renamed while others should be left untouched)