### PR TITLE
DSCPDC 429 add tsvToMsg and tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -77,6 +77,7 @@ lazy val common = project
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
+      "ch.qos.logback" % "logback-classic" % logbackVersion,
       "com.lihaoyi" %% "upickle" % uPickleVersion,
       "com.spotify" %% "scio-core" % scioVersion,
       "io.circe" %% "circe-parser" % circeVersion
@@ -115,7 +116,6 @@ lazy val v2f = project
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "ch.qos.logback" % "logback-classic" % logbackVersion,
       "com.spotify" %% "scio-extra" % scioVersion,
       "com.github.tototoshi" %% "scala-csv" % scalaCsvVersion,
       "com.github.pathikrit" %% "better-files" % betterFilesVersion,

--- a/common/src/test/resources/logback-test.xml
+++ b/common/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Use debug level for our own messages so we can eyeball logs during testing. -->
+    <logger name="org.broadinstitute" level="DEBUG" additivity="false">
+        <appender-ref ref="STDOUT" />
+    </logger>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/v2f/src/main/scala/org/broadinstitute/monster/etl/v2f/V2FUtils.scala
+++ b/v2f/src/main/scala/org/broadinstitute/monster/etl/v2f/V2FUtils.scala
@@ -69,7 +69,7 @@ object V2FUtils {
     }
 
   /**
-    * Given the ReadableFile that contains TSVs convert each TSV to a Msg and get its filepath.
+    * Given the SCollection of ReadableFiles that contains TSVs convert each TSV to a Msg and get its filepath.
     *
     * @param tableName the name of the TSV table that was converted to Msg
     */
@@ -87,8 +87,10 @@ object V2FUtils {
             reader.allWithHeaders().map { map =>
               val msgObj = Obj()
               map.foreach {
-                case (key, value) if value != "" =>
-                  msgObj.value.update(Str(key), Str(value.trim))
+                case (key, value) =>
+                  if (value != "") {
+                    msgObj.value.update(Str(key), Str(value.trim))
+                  }
               }
               val filePath = file.getMetadata.resourceId.getCurrentDirectory.toString
               (filePath, msgObj)

--- a/v2f/src/main/scala/org/broadinstitute/monster/etl/v2f/V2FUtils.scala
+++ b/v2f/src/main/scala/org/broadinstitute/monster/etl/v2f/V2FUtils.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.monster.etl.v2f
 
 import upack._
-
 import java.io.InputStreamReader
 import java.nio.channels.Channels
 
@@ -13,6 +12,7 @@ import com.spotify.scio.values.SCollection
 import io.circe.{Json, JsonObject}
 import org.apache.beam.sdk.io.FileIO
 import org.apache.beam.sdk.io.FileIO.ReadableFile
+import org.broadinstitute.monster.etl.UpackMsgCoder
 
 import scala.util.Try
 import scala.util.matching.Regex
@@ -23,6 +23,7 @@ import scala.util.matching.Regex
 object V2FUtils {
 
   implicit val jsonCoder: Coder[JsonObject] = Coder.kryo[JsonObject]
+  implicit val msgCoder: Coder[Msg] = Coder.beam(new UpackMsgCoder)
   implicit val readableFileCoder: Coder[ReadableFile] = Coder.kryo[ReadableFile]
 
   /**
@@ -68,7 +69,7 @@ object V2FUtils {
     }
 
   /**
-    * Given the ReadableFile that contains TSVs convert each TSV to a Msg and get is filepath.
+    * Given the ReadableFile that contains TSVs convert each TSV to a Msg and get its filepath.
     *
     * @param tableName the name of the TSV table that was converted to Msg
     */

--- a/v2f/src/main/scala/org/broadinstitute/monster/etl/v2f/V2FUtils.scala
+++ b/v2f/src/main/scala/org/broadinstitute/monster/etl/v2f/V2FUtils.scala
@@ -1,6 +1,5 @@
 package org.broadinstitute.monster.etl.v2f
 
-import upack._
 import java.io.InputStreamReader
 import java.nio.channels.Channels
 
@@ -13,6 +12,7 @@ import io.circe.{Json, JsonObject}
 import org.apache.beam.sdk.io.FileIO
 import org.apache.beam.sdk.io.FileIO.ReadableFile
 import org.broadinstitute.monster.etl.UpackMsgCoder
+import upack._
 
 import scala.util.Try
 import scala.util.matching.Regex
@@ -76,7 +76,7 @@ object V2FUtils {
   def tsvToMsg(
     tableName: String
   ): SCollection[ReadableFile] => SCollection[(String, Msg)] =
-    _.transform(s"Convert $tableName TSVs to Msg") { collection =>
+    _.transform(s"Extract $tableName TSV rows") { collection =>
       collection.flatMap { file =>
         Channels
           .newInputStream(file.open())
@@ -88,8 +88,9 @@ object V2FUtils {
               val msgObj = Obj()
               map.foreach {
                 case (key, value) =>
-                  if (value != "") {
-                    msgObj.value.update(Str(key), Str(value.trim))
+                  val trimmed = value.trim
+                  if (trimmed != "") {
+                    msgObj.value.update(Str(key), Str(trimmed))
                   }
               }
               val filePath = file.getMetadata.resourceId.getCurrentDirectory.toString

--- a/v2f/src/test/resources/logback-test.xml
+++ b/v2f/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Use debug level for our own messages so we can eyeball logs during testing. -->
+    <logger name="org.broadinstitute" level="DEBUG" additivity="false">
+        <appender-ref ref="STDOUT" />
+    </logger>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/v2f/src/test/scala/org/broadinstitute/monster/etl/v2f/V2FUtilsSpec.scala
+++ b/v2f/src/test/scala/org/broadinstitute/monster/etl/v2f/V2FUtilsSpec.scala
@@ -2,8 +2,8 @@ package org.broadinstitute.monster.etl.v2f
 
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.testing._
-import org.scalatest.Matchers
 import org.broadinstitute.monster.etl.UpackMsgCoder
+import org.scalatest.Matchers
 import upack.{Msg, Obj, Str}
 
 class V2FUtilsSpec extends PipelineSpec with Matchers {

--- a/v2f/src/test/scala/org/broadinstitute/monster/etl/v2f/V2FUtilsSpec.scala
+++ b/v2f/src/test/scala/org/broadinstitute/monster/etl/v2f/V2FUtilsSpec.scala
@@ -85,7 +85,7 @@ class V2FUtilsSpec extends PipelineSpec with Matchers {
       {
         V2FUtils.tsvToMsg("testTableName")(
           V2FUtils.getReadableFiles(
-            "/Users/rarshad/Projects/monster-etl/v2f/src/test/scala/org/broadinstitute/monster/etl/v2f/tsvTestFileOriginal.txt",
+            "src/test/scala/org/broadinstitute/monster/etl/v2f/tsvTestFileOriginal.txt",
             sc
           )
         )
@@ -103,7 +103,7 @@ class V2FUtilsSpec extends PipelineSpec with Matchers {
       {
         V2FUtils.tsvToMsg("testTableName")(
           V2FUtils.getReadableFiles(
-            "/Users/rarshad/Projects/monster-etl/v2f/src/test/scala/org/broadinstitute/monster/etl/v2f/tsvTestFileMissingValues.txt",
+            "src/test/scala/org/broadinstitute/monster/etl/v2f/tsvTestFileMissingValues.txt",
             sc
           )
         )
@@ -120,7 +120,7 @@ class V2FUtilsSpec extends PipelineSpec with Matchers {
       {
         V2FUtils.tsvToMsg("testTableName")(
           V2FUtils.getReadableFiles(
-            "/Users/rarshad/Projects/monster-etl/v2f/src/test/scala/org/broadinstitute/monster/etl/v2f/*.txt",
+            "src/test/scala/org/broadinstitute/monster/etl/v2f/*.txt",
             sc
           )
         )

--- a/v2f/src/test/scala/org/broadinstitute/monster/etl/v2f/V2FUtilsSpec.scala
+++ b/v2f/src/test/scala/org/broadinstitute/monster/etl/v2f/V2FUtilsSpec.scala
@@ -1,8 +1,8 @@
 package org.broadinstitute.monster.etl.v2f
 
 import com.spotify.scio.coders.Coder
-import org.scalatest.Matchers
 import com.spotify.scio.testing._
+import org.scalatest.Matchers
 import org.broadinstitute.monster.etl.UpackMsgCoder
 import upack.{Msg, Obj, Str}
 

--- a/v2f/src/test/scala/org/broadinstitute/monster/etl/v2f/V2FUtilsSpec.scala
+++ b/v2f/src/test/scala/org/broadinstitute/monster/etl/v2f/V2FUtilsSpec.scala
@@ -1,0 +1,86 @@
+package org.broadinstitute.monster.etl.v2f
+
+import com.spotify.scio.coders.Coder
+import org.scalatest.Matchers
+import com.spotify.scio.testing._
+import org.broadinstitute.monster.etl.UpackMsgCoder
+import upack.{Msg, Obj, Str}
+
+class V2FUtilsSpec extends PipelineSpec with Matchers {
+
+  implicit val msgCoder: Coder[Msg] = Coder.beam(new UpackMsgCoder)
+
+  behavior of "V2FUtils"
+
+  private val tsvMsgOriginal = List {
+    Obj(
+      Str("key1") -> Str("v11"),
+      Str("key2") -> Str("v21"),
+      Str("key3") -> Str("v31"),
+      Str("key4") -> Str("v41"),
+      Str("key5") -> Str("v51")
+    )
+    Obj(
+      Str("key1") -> Str("v12"),
+      Str("key2") -> Str("v22"),
+      Str("key3") -> Str("v32"),
+      Str("key4") -> Str("v42"),
+      Str("key5") -> Str("v52")
+    )
+  }
+
+  private val tsvMsgDiffOrder = List {
+    Obj(
+      Str("key1") -> Str("v11"),
+      Str("key5") -> Str("v51"),
+      Str("key2") -> Str("v21"),
+      Str("key4") -> Str("v41"),
+      Str("key3") -> Str("v31")
+    )
+    Obj(
+      Str("key1") -> Str("v12"),
+      Str("key5") -> Str("v52"),
+      Str("key2") -> Str("v22"),
+      Str("key4") -> Str("v42"),
+      Str("key3") -> Str("v32")
+    )
+  }
+
+  private val tsvMsgDiffCols = List {
+    Obj(
+      Str("key10") -> Str("v101"),
+      Str("key20") -> Str("v201"),
+      Str("key30") -> Str("v301"),
+      Str("key40") -> Str("v401"),
+      Str("key50") -> Str("v501")
+    )
+    Obj(
+      Str("key10") -> Str("v102"),
+      Str("key20") -> Str("v202"),
+      Str("key30") -> Str("v302"),
+      Str("key40") -> Str("v402"),
+      Str("key50") -> Str("v502")
+    )
+  }
+
+  it should "convert each row of the TSV in an input stream to a Msg" in {
+
+    val (_, readMessages) = runWithLocalOutput { sc =>
+      {
+        V2FUtils.tsvToMsg("testTableName")(
+          V2FUtils.getReadableFiles(
+            "/Users/rarshad/Projects/monster-etl/v2f/src/test/scala/org/broadinstitute/monster/etl/v2f/*.txt",
+            sc
+          )
+        )
+      }
+    }
+
+    val out = readMessages.map(_._2)
+
+    out should contain allElementsOf tsvMsgOriginal
+  }
+
+//  it should "skip key-value pairs in a TSV where the value is an empty string" in {
+//  }
+}

--- a/v2f/src/test/scala/org/broadinstitute/monster/etl/v2f/tsvTestFile1.txt
+++ b/v2f/src/test/scala/org/broadinstitute/monster/etl/v2f/tsvTestFile1.txt
@@ -1,0 +1,3 @@
+key1	key2	key3	key4	key5
+v11	v21	v31	v41	v51
+v12	v22	v32	v42	v52

--- a/v2f/src/test/scala/org/broadinstitute/monster/etl/v2f/tsvTestFile1.txt
+++ b/v2f/src/test/scala/org/broadinstitute/monster/etl/v2f/tsvTestFile1.txt
@@ -1,3 +1,0 @@
-key1	key2	key3	key4	key5
-v11	v21	v31	v41	v51
-v12	v22	v32	v42	v52

--- a/v2f/src/test/scala/org/broadinstitute/monster/etl/v2f/tsvTestFileDiffCols.txt
+++ b/v2f/src/test/scala/org/broadinstitute/monster/etl/v2f/tsvTestFileDiffCols.txt
@@ -1,0 +1,3 @@
+key10	key20	key30	key40	key50
+v101	v201	v301	v401	v501
+v102	v202	v302	v402	v502

--- a/v2f/src/test/scala/org/broadinstitute/monster/etl/v2f/tsvTestFileDiffOrder.txt
+++ b/v2f/src/test/scala/org/broadinstitute/monster/etl/v2f/tsvTestFileDiffOrder.txt
@@ -1,0 +1,3 @@
+key1	key5	key2	key4	key3
+v11	v51	v21	v41	v31
+v12	v52	v22	v42	v32

--- a/v2f/src/test/scala/org/broadinstitute/monster/etl/v2f/tsvTestFileMissingValues.txt
+++ b/v2f/src/test/scala/org/broadinstitute/monster/etl/v2f/tsvTestFileMissingValues.txt
@@ -1,0 +1,3 @@
+key1	key2	key3	key4	key5	key6
+v11	v21		v41	v51	
+v12	v22	v32		v52	

--- a/v2f/src/test/scala/org/broadinstitute/monster/etl/v2f/tsvTestFileMissingValues.txt
+++ b/v2f/src/test/scala/org/broadinstitute/monster/etl/v2f/tsvTestFileMissingValues.txt
@@ -1,3 +1,3 @@
 key1	key2	key3	key4	key5	key6
 v11	v21		v41	v51	
-v12	v22	v32		v52	
+v12	v22	v32	 	v52	

--- a/v2f/src/test/scala/org/broadinstitute/monster/etl/v2f/tsvTestFileOriginal.txt
+++ b/v2f/src/test/scala/org/broadinstitute/monster/etl/v2f/tsvTestFileOriginal.txt
@@ -1,0 +1,3 @@
+key1	key2	key3	key4	key5
+v11	v21	v31	v41	v51
+v12	v22	v32	v42	v52


### PR DESCRIPTION
Also added `logback-test.xml` files, some .txt files that are the reference TSV files for testing `tsvToMsg`, and updated a logging configuration in `build.sbt`