### PR TITLE
V2F refactor

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,12 +18,17 @@ pipeline {
         }
         stage('Compile') {
             steps {
-                sh 'sbt Compile/compile Test/compile'
+                sh 'sbt Compile/compile Test/compile IntegrationTest/compile'
             }
         }
         stage('Test') {
             steps {
                 sh 'sbt test'
+            }
+        }
+        stage('Integration test') {
+            steps {
+                sh 'sbt IntegrationTest/test'
             }
         }
     }

--- a/v2f/src/main/scala/org/broadinstitute/monster/etl/v2f/ExtractionPipeline.scala
+++ b/v2f/src/main/scala/org/broadinstitute/monster/etl/v2f/ExtractionPipeline.scala
@@ -71,15 +71,14 @@ object ExtractionPipeline {
         inputDir = inputDir
       )
 
+    val maasWithAncestryID = V2FUtils.addAncestryID(
+      MetaAnalysisAncestrySpecific.tableName
+    )(maasExtractedAndConverted)
+
     val maasTransformed =
       V2FExtractionsAndTransforms.transform(
         MetaAnalysisAncestrySpecific
-      )(maasExtractedAndConverted)
-
-    val maasTransformedAndAncestryID =
-      V2FUtils.addAncestryID(MetaAnalysisAncestrySpecific.tableName)(
-        maasTransformed
-      )
+      )(maasWithAncestryID)
 
     // MetaAnalysisTransEthnic
     val mateExtractedAndConverted =
@@ -162,7 +161,7 @@ object ExtractionPipeline {
     )
 
     writeToDisk(
-      maasTransformedAndAncestryID,
+      maasTransformed,
       MetaAnalysisAncestrySpecific.tableName,
       filePath = MetaAnalysisAncestrySpecific.filePath,
       outputDir
@@ -199,13 +198,13 @@ object ExtractionPipeline {
     * @param outputDir the root outputs directory where the JSON file(s) will be saved
     */
   def writeToDisk(
-    msgAndFilePaths: SCollection[(String, Msg)],
+    msgAndFilePaths: SCollection[Msg],
     description: String,
     filePath: String,
     outputDir: String
   ): Unit = {
     MsgIO.writeJsonLists(
-      msgAndFilePaths.map { case (_, msgObj) => msgObj },
+      msgAndFilePaths,
       description,
       s"$outputDir/$filePath"
     )

--- a/v2f/src/main/scala/org/broadinstitute/monster/etl/v2f/V2FExtractionsAndTransforms.scala
+++ b/v2f/src/main/scala/org/broadinstitute/monster/etl/v2f/V2FExtractionsAndTransforms.scala
@@ -48,9 +48,9 @@ object V2FExtractionsAndTransforms {
   def extractAndTransformVariants(
     v2fConstant: V2FConstants,
     msgAndFilePaths: SCollection[(String, Msg)]
-  ): SCollection[(String, Msg)] = {
+  ): SCollection[Msg] = {
     msgAndFilePaths.map {
-      case (path, msg) =>
+      case (_, msg) =>
         // rename fields
         val withRenamedFields =
           MsgTransformations.renameFields(v2fConstant.variantFieldsToRename)(msg)
@@ -65,7 +65,7 @@ object V2FExtractionsAndTransforms {
             withExtractedFields
           )
         // return final
-        (path, withLongs)
+        withLongs
     }
   }
 
@@ -76,9 +76,9 @@ object V2FExtractionsAndTransforms {
     */
   def transform(
     v2fConstant: V2FConstants
-  ): SCollection[(String, Msg)] => SCollection[(String, Msg)] = { msgAndFilePaths =>
+  ): SCollection[(String, Msg)] => SCollection[Msg] = { msgAndFilePaths =>
     msgAndFilePaths.map {
-      case (path, msg) =>
+      case (_, msg) =>
         // rename fields
         val withRenamedFields =
           MsgTransformations.renameFields(v2fConstant.fieldsToRename)(msg)
@@ -117,7 +117,7 @@ object V2FExtractionsAndTransforms {
               )(currentMsg)
           }
         // return final Msg
-        (path, withDoubleArrays)
+        withDoubleArrays
     }
   }
 
@@ -127,15 +127,10 @@ object V2FExtractionsAndTransforms {
     * @param variantMsgAndFilePaths a list of the collections of Msg Objects and associated file paths that will be merged and then saved as a Msg file
     */
   def mergeVariantMsgs(
-    variantMsgAndFilePaths: List[SCollection[(String, Msg)]]
+    variantMsgAndFilePaths: List[SCollection[Msg]]
   ): SCollection[Msg] = {
     SCollection
-      .unionAll(variantMsgAndFilePaths.map { collection =>
-        collection.map {
-          case (_, msgObj) =>
-            msgObj
-        }
-      })
+      .unionAll(variantMsgAndFilePaths)
       .distinctBy(_.obj.apply(Str("id")).str)
   }
 }


### PR DESCRIPTION
refactor to eliminate carrying through the filePath in as many methods as possible while maintaining it for the ancestry-specific files. Tests still pass somehow :tada: