### PR TITLE
Ra dspdc 598 vcv trait and set

### DIFF
--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/ArchiveBranches.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/ArchiveBranches.scala
@@ -25,7 +25,9 @@ case class ArchiveBranches(
   scvVariations: SCollection[WithContent[SCVVariation]],
   scvObservations: SCollection[WithContent[SCVObservation]],
   scvTraitSets: SCollection[WithContent[SCVTraitSet]],
-  scvTraits: SCollection[WithContent[SCVTrait]]
+  scvTraits: SCollection[WithContent[SCVTrait]],
+  vcvTraitSets: SCollection[WithContent[VCVTraitSet]],
+  vcvTraits: SCollection[WithContent[VCVTrait]]
 )
 
 object ArchiveBranches {
@@ -51,6 +53,8 @@ object ArchiveBranches {
     val scvObservationOut = SideOutput[WithContent[SCVObservation]]
     val scvTraitSetOut = SideOutput[WithContent[SCVTraitSet]]
     val scvTraitOut = SideOutput[WithContent[SCVTrait]]
+    val vcvTraitSetOut = SideOutput[WithContent[VCVTraitSet]]
+    val vcvTraitOut = SideOutput[WithContent[VCVTrait]]
 
     val (variationStream, sideCtx) = archiveStream
       .withSideOutputs(
@@ -105,7 +109,9 @@ object ArchiveBranches {
       scvVariations = sideCtx(scvVariationOut),
       scvObservations = sideCtx(scvObservationOut),
       scvTraitSets = sideCtx(scvTraitSetOut),
-      scvTraits = sideCtx(scvTraitOut)
+      scvTraits = sideCtx(scvTraitOut),
+      vcvTraitSets = sideCtx(vcvTraitSetOut),
+      vcvTraits = sideCtx(vcvTraitOut)
     )
   }
 }

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/ArchiveBranches.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/ArchiveBranches.scala
@@ -114,8 +114,8 @@ object ArchiveBranches {
       scvObservations = sideCtx(scvObservationOut),
       scvTraitSets = sideCtx(scvTraitSetOut),
       scvTraits = sideCtx(scvTraitOut),
-      vcvTraitSets = sideCtx(vcvTraitSetOut),
-      vcvTraits = sideCtx(vcvTraitOut)
+      vcvTraitSets = sideCtx(vcvTraitSetOut).distinctBy(_.data.id),
+      vcvTraits = sideCtx(vcvTraitOut).distinctBy(_.data.id)
     )
   }
 }

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/ArchiveBranches.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/ArchiveBranches.scala
@@ -69,7 +69,9 @@ object ArchiveBranches {
         scvVariationOut,
         scvObservationOut,
         scvTraitSetOut,
-        scvTraitOut
+        scvTraitOut,
+        vcvTraitSetOut,
+        vcvTraitOut
       )
       .withName("Split Variation Archives")
       .map { (rawArchive, ctx) =>

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/ArchiveBranches.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/ArchiveBranches.scala
@@ -93,6 +93,8 @@ object ArchiveBranches {
         parsed.scvObservations.foreach(ctx.output(scvObservationOut, _))
         parsed.scvTraitSets.foreach(ctx.output(scvTraitSetOut, _))
         parsed.scvTraits.foreach(ctx.output(scvTraitOut, _))
+        parsed.vcvTraitSets.foreach(ctx.output(vcvTraitSetOut, _))
+        parsed.vcvTraits.foreach(ctx.output(vcvTraitOut, _))
         // Use variation as the main output because each archive contains
         // exactly one of them.
         parsed.variation

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/ClinvarPipeline.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/ClinvarPipeline.scala
@@ -103,6 +103,16 @@ object ClinvarPipeline {
       "SCV Traits",
       s"${parsedArgs.outputPrefix}/clinical_assertion_trait"
     )
+    MsgIO.writeJsonLists(
+      archiveBranches.vcvTraitSets,
+      "VCV Trait Sets",
+      s"${parsedArgs.outputPrefix}/variation_archive_trait_set"
+    )
+    MsgIO.writeJsonLists(
+      archiveBranches.vcvTraits,
+      "VCV Traits",
+      s"${parsedArgs.outputPrefix}/variation_archive_trait"
+    )
 
     pipelineContext.run()
     ()

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/ClinvarPipeline.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/ClinvarPipeline.scala
@@ -106,12 +106,12 @@ object ClinvarPipeline {
     MsgIO.writeJsonLists(
       archiveBranches.vcvTraitSets,
       "VCV Trait Sets",
-      s"${parsedArgs.outputPrefix}/variation_archive_trait_set"
+      s"${parsedArgs.outputPrefix}/trait_set"
     )
     MsgIO.writeJsonLists(
       archiveBranches.vcvTraits,
       "VCV Traits",
-      s"${parsedArgs.outputPrefix}/variation_archive_trait"
+      s"${parsedArgs.outputPrefix}/trait"
     )
 
     pipelineContext.run()

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/intermediate/VariationArchive.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/intermediate/VariationArchive.scala
@@ -174,13 +174,11 @@ object VariationArchive {
         }
 
       interp.extractList("ConditionList", "TraitSet").foreach { rawTraitSet =>
-        val vcvTraitSet = VCVTraitSet.fromRawSet(rawTraitSet)
-
         MsgTransformations.popAsArray(rawTraitSet, "Trait").foreach { rawTrait =>
-          val vcvTrait = VCVTrait.fromRawTrait(vcvTraitSet, rawTrait)
+          val vcvTrait = VCVTrait.fromRawTrait(rawTrait)
           vcvTraits.append(WithContent.attachContent(vcvTrait, rawTrait))
         }
-
+        val vcvTraitSet = VCVTraitSet.fromRawSet(rawTraitSet, vcvTraits)
         vcvTraitSets.append(WithContent.attachContent(vcvTraitSet, rawTraitSet))
       }
 

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/intermediate/VariationArchive.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/intermediate/VariationArchive.scala
@@ -156,10 +156,24 @@ object VariationArchive {
       val vcv = VCV.fromRawArchive(variation, rawArchive)
       val vcvRelease = VCVRelease.fromRawArchive(vcv, rawArchive)
 
+      val vcvTraitSets = new mutable.ArrayBuffer[WithContent[VCVTraitSet]]()
+      val vcvTraits = new mutable.ArrayBuffer[WithContent[VCVTrait]]()
+
       // Pull out any RCVs.
       val rcvs = variationRecord.extractList("RCVList", "RCVAccession").map { rawRcv =>
         val rcv = RCV.fromRawAccession(variation, vcv, rawRcv)
         WithContent.attachContent(rcv, rawRcv)
+      }
+
+      // TODO INTERP THINGS FOR FUTURE DAN AND RAAID
+      val interp = variationRecord.extract("Interpretations", "Interpretation").getOrElse {
+        throw new IllegalStateException(s"Found a VCV with no Interpretation: $variationRecord")
+      }
+
+      interp.extractList("ConditionList", "TraitSet").foreach {
+        rawTraitSet =>
+          val traitSet = VCVTraitSet.fromRawSet(rawTraitSet)
+          vcvTraitSets.append(WithContent.attachContent(traitSet, rawTraitSet))
       }
 
       // Pull out any SCVs, and related info.
@@ -170,8 +184,6 @@ object VariationArchive {
       val observations = new mutable.ArrayBuffer[WithContent[SCVObservation]]()
       val scvTraitSets = new mutable.ArrayBuffer[WithContent[SCVTraitSet]]()
       val scvTraits = new mutable.ArrayBuffer[WithContent[SCVTrait]]()
-      val vcvTraitSets = new mutable.ArrayBuffer[WithContent[VCVTraitSet]]()
-      val vcvTraits = new mutable.ArrayBuffer[WithContent[VCVTrait]]()
 
       variationRecord.extractList("ClinicalAssertionList", "ClinicalAssertion").foreach {
         rawScv =>

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/intermediate/VariationArchive.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/intermediate/VariationArchive.scala
@@ -37,6 +37,10 @@ import scala.collection.mutable
   * @param scvTraitSets info about collections of `scvTraits` which were submitted
   *                     as part of each item in `scvs`
   * @param scvTraits info about traits that were submitted for each item in `scvs`
+  *
+  * @param vcvTraitSets info about collections of `vcvTraits`
+  *
+  * @param vcvTraits info about traits
   */
 case class VariationArchive(
   variation: WithContent[Variation],
@@ -51,7 +55,9 @@ case class VariationArchive(
   scvVariations: Array[WithContent[SCVVariation]],
   scvObservations: Array[WithContent[SCVObservation]],
   scvTraitSets: Array[WithContent[SCVTraitSet]],
-  scvTraits: Array[WithContent[SCVTrait]]
+  scvTraits: Array[WithContent[SCVTrait]],
+  vcvTraitSets: Array[WithContent[VCVTraitSet]],
+  vcvTraits: Array[WithContent[VCVTrait]]
 )
 
 object VariationArchive {
@@ -138,7 +144,9 @@ object VariationArchive {
       submissions = Array.empty,
       scvObservations = Array.empty,
       scvTraitSets = Array.empty,
-      scvTraits = Array.empty
+      scvTraits = Array.empty,
+      vcvTraitSets = Array.empty,
+      vcvTraits = Array.empty
     )
 
     // Since IncludedRecords don't contain meaningful provenance, we only
@@ -162,6 +170,8 @@ object VariationArchive {
       val observations = new mutable.ArrayBuffer[WithContent[SCVObservation]]()
       val scvTraitSets = new mutable.ArrayBuffer[WithContent[SCVTraitSet]]()
       val scvTraits = new mutable.ArrayBuffer[WithContent[SCVTrait]]()
+      val vcvTraitSets = new mutable.ArrayBuffer[WithContent[VCVTraitSet]]()
+      val vcvTraits = new mutable.ArrayBuffer[WithContent[VCVTrait]]()
 
       variationRecord.extractList("ClinicalAssertionList", "ClinicalAssertion").foreach {
         rawScv =>
@@ -228,7 +238,9 @@ object VariationArchive {
         submissions = submissions.toArray,
         scvObservations = observations.toArray,
         scvTraitSets = scvTraitSets.toArray,
-        scvTraits = scvTraits.toArray
+        scvTraits = scvTraits.toArray,
+        vcvTraitSets = vcvTraitSets.toArray,
+        vcvTraits = vcvTraits.toArray
       )
     } else {
       outputBase

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/intermediate/VariationArchive.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/intermediate/VariationArchive.scala
@@ -166,21 +166,22 @@ object VariationArchive {
       }
 
       // TODO INTERP THINGS FOR FUTURE DAN AND RAAID
-      val interp = variationRecord.extract("Interpretations", "Interpretation").getOrElse {
-        throw new IllegalStateException(s"Found a VCV with no Interpretation: $variationRecord")
-      }
+      val interp =
+        variationRecord.extract("Interpretations", "Interpretation").getOrElse {
+          throw new IllegalStateException(
+            s"Found a VCV with no Interpretation: $variationRecord"
+          )
+        }
 
-      interp.extractList("ConditionList", "TraitSet").foreach {
-        rawTraitSet =>
-          val vcvTraitSet = VCVTraitSet.fromRawSet(rawTraitSet)
+      interp.extractList("ConditionList", "TraitSet").foreach { rawTraitSet =>
+        val vcvTraitSet = VCVTraitSet.fromRawSet(rawTraitSet)
 
-          MsgTransformations.popAsArray(rawTraitSet, "Trait").foreach {
-            rawTrait =>
-              val vcvTrait = VCVTrait.fromRawTrait(vcvTraitSet, rawTrait)
-              vcvTraits.append(WithContent.attachContent(vcvTrait, rawTrait))
-          }
+        MsgTransformations.popAsArray(rawTraitSet, "Trait").foreach { rawTrait =>
+          val vcvTrait = VCVTrait.fromRawTrait(vcvTraitSet, rawTrait)
+          vcvTraits.append(WithContent.attachContent(vcvTrait, rawTrait))
+        }
 
-          vcvTraitSets.append(WithContent.attachContent(vcvTraitSet, rawTraitSet))
+        vcvTraitSets.append(WithContent.attachContent(vcvTraitSet, rawTraitSet))
       }
 
       // Pull out any SCVs, and related info.

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/intermediate/VariationArchive.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/intermediate/VariationArchive.scala
@@ -172,8 +172,15 @@ object VariationArchive {
 
       interp.extractList("ConditionList", "TraitSet").foreach {
         rawTraitSet =>
-          val traitSet = VCVTraitSet.fromRawSet(rawTraitSet)
-          vcvTraitSets.append(WithContent.attachContent(traitSet, rawTraitSet))
+          val vcvTraitSet = VCVTraitSet.fromRawSet(rawTraitSet)
+
+          MsgTransformations.popAsArray(rawTraitSet, "Trait").foreach {
+            rawTrait =>
+              val vcvTrait = VCVTrait.fromRawTrait(vcvTraitSet, rawTrait)
+              vcvTraits.append(WithContent.attachContent(vcvTrait, rawTrait))
+          }
+
+          vcvTraitSets.append(WithContent.attachContent(vcvTraitSet, rawTraitSet))
       }
 
       // Pull out any SCVs, and related info.

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/intermediate/VariationArchive.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/intermediate/VariationArchive.scala
@@ -174,11 +174,13 @@ object VariationArchive {
         }
 
       interp.extractList("ConditionList", "TraitSet").foreach { rawTraitSet =>
+        val currentVcvTraitIds = new mutable.ArrayBuffer[String]()
         MsgTransformations.popAsArray(rawTraitSet, "Trait").foreach { rawTrait =>
           val vcvTrait = VCVTrait.fromRawTrait(rawTrait)
           vcvTraits.append(WithContent.attachContent(vcvTrait, rawTrait))
+          currentVcvTraitIds.append(vcvTrait.id)
         }
-        val vcvTraitSet = VCVTraitSet.fromRawSet(rawTraitSet, vcvTraits)
+        val vcvTraitSet = VCVTraitSet.fromRawSet(rawTraitSet, currentVcvTraitIds.toArray)
         vcvTraitSets.append(WithContent.attachContent(vcvTraitSet, rawTraitSet))
       }
 

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTrait.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTrait.scala
@@ -32,10 +32,10 @@ object VCVTrait {
 
   /** Extract a VCVTrait from a raw Trait payload. */
   def fromRawTrait(
-                    traitSet: SCVTraitSet,
+                    traitSet: VCVTraitSet,
                     counter: AtomicInteger,
                     rawTrait: Msg
-                  ): SCVTrait = {
+                  ): VCVTrait = {
     val nameWrapper = rawTrait.extract("Name", "ElementValue")
     val allXrefs = MsgTransformations.popAsArray(rawTrait, "XRef")
     val (medgenId, xrefs) =

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTrait.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTrait.scala
@@ -1,0 +1,78 @@
+package org.broadinstitute.monster.etl.clinvar.models.output
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import io.circe.Encoder
+import io.circe.derivation.{deriveEncoder, renaming}
+import org.broadinstitute.monster.etl.MsgTransformations
+import org.broadinstitute.monster.etl.clinvar.ClinvarConstants
+import ujson.StringRenderer
+import upack.{Msg, Obj, Str}
+
+/**
+  * Info about a trait approved by ClinVar.
+  *
+  * @param id unique ID of the trait, corresponding to ClinVar's internal TraitID
+  * @param medgenTraitId unique ID of the trait in NCBI's MedGen database,
+  *                      if known
+  * @param name full name of the trait
+  * @param `type` type of the trait
+  */
+case class VCVTrait(
+                     id: String,
+                     medgenTraitId: Option[String],
+                     name: Option[String],
+                     `type`: Option[String]
+                   )
+
+object VCVTrait {
+  import org.broadinstitute.monster.etl.clinvar.MsgOps
+
+  implicit val encoder: Encoder[VCVTrait] = deriveEncoder(renaming.snakeCase, None)
+
+  /** Extract a VCVTrait from a raw Trait payload. */
+  def fromRawTrait(
+                    traitSet: SCVTraitSet,
+                    counter: AtomicInteger,
+                    rawTrait: Msg
+                  ): SCVTrait = {
+    val nameWrapper = rawTrait.extract("Name", "ElementValue")
+    val allXrefs = MsgTransformations.popAsArray(rawTrait, "XRef")
+    val (medgenId, xrefs) =
+      allXrefs.foldLeft((Option.empty[String], List.empty[String])) {
+        case ((medgenAcc, xrefAcc), xref) =>
+          val db = xref.obj.get(Str("@DB")).map(_.str)
+          val id = xref.obj.get(Str("@ID")).map(_.str)
+
+          if (db.contains(ClinvarConstants.MedGenKey)) {
+            if (medgenAcc.isDefined) {
+              throw new IllegalStateException(
+                s"SCV Trait in set ${traitSet.id} contains two MedGen references"
+              )
+            } else {
+              (id, xrefAcc)
+            }
+          } else {
+            val cleaned = Obj()
+            xref.obj.foreach {
+              case (k, v) =>
+                val cleanedKey =
+                  MsgTransformations.keyToSnakeCase(k.str.replaceAllLiterally("@", ""))
+                cleaned.obj.update(Str(cleanedKey), v)
+            }
+            val stringifiedRef = upack.transform(cleaned, StringRenderer()).toString
+
+            (medgenAcc, stringifiedRef :: xrefAcc)
+          }
+      }
+
+    SCVTrait(
+      id = s"${traitSet.id}.${counter.getAndIncrement()}",
+      clinicalAssertionTraitSetId = traitSet.id,
+      medgenTraitId = medgenId,
+      name = nameWrapper.flatMap(_.extract("$")).map(_.str),
+      `type` = rawTrait.extract("@Type").map(_.str),
+      xrefs = xrefs.toArray
+    )
+  }
+}

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTrait.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTrait.scala
@@ -62,7 +62,7 @@ object VCVTrait {
     VCVTrait(
       id = rawTrait.extract("@ID").map(_.str).get,
       medgenTraitId = medgenId,
-      name = rawTrait.extract("Name", "ElementValue").flatMap(_.extract("$")).map(_.str),
+      name = rawTrait.extract("Name", "ElementValue", "$").map(_.str),
       `type` = rawTrait.extract("@Type").map(_.str)
     )
   }

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTrait.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTrait.scala
@@ -76,7 +76,8 @@ object VCVTrait {
         throw new IllegalStateException(s"Found a VCV Trait with no ID: $rawTrait")
       },
       medgenTraitId = medgenId,
-      name = preferredNameArray.headOption.flatMap(_.extract("ElementValue").get.extract("$").map(_.str)),
+      name = preferredNameArray.headOption
+        .flatMap(_.extract("ElementValue").get.extract("$").map(_.str)),
       `type` = rawTrait.extract("@Type").map(_.str),
       otherXrefs = otherXrefs.toArray
     )

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTrait.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTrait.scala
@@ -31,7 +31,7 @@ object VCVTrait {
   def fromRawTrait(traitSet: VCVTraitSet, rawTrait: Msg): VCVTrait = {
 
     val preferredNameArray = MsgTransformations
-      .popAsArray(rawTrait, "Name")
+      .getAsArray(rawTrait, "Name")
       .filter(_.obj(Str("ElementValue")).obj(Str("@Type")).str == "Preferred")
       .toArray
 
@@ -73,7 +73,7 @@ object VCVTrait {
     VCVTrait(
       id = rawTrait.extract("@ID").map(_.str).get,
       medgenTraitId = medgenId,
-      name = preferredNameArray(0).obj(Str("ElementValue")).extract("$").map(_.str),
+      name = preferredNameArray(0).extract("ElementValue").get.extract("$").map(_.str),
       `type` = rawTrait.extract("@Type").map(_.str)
     )
   }

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTrait.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTrait.scala
@@ -1,7 +1,5 @@
 package org.broadinstitute.monster.etl.clinvar.models.output
 
-import java.util.concurrent.atomic.AtomicInteger
-
 import io.circe.Encoder
 import io.circe.derivation.{deriveEncoder, renaming}
 import org.broadinstitute.monster.etl.MsgTransformations
@@ -19,11 +17,11 @@ import upack.{Msg, Obj, Str}
   * @param `type` type of the trait
   */
 case class VCVTrait(
-                     id: String,
-                     medgenTraitId: Option[String],
-                     name: Option[String],
-                     `type`: Option[String]
-                   )
+  id: String,
+  medgenTraitId: Option[String],
+  name: Option[String],
+  `type`: Option[String]
+)
 
 object VCVTrait {
   import org.broadinstitute.monster.etl.clinvar.MsgOps
@@ -33,7 +31,7 @@ object VCVTrait {
   /** Extract a VCVTrait from a raw Trait payload. */
   def fromRawTrait(traitSet: VCVTraitSet, rawTrait: Msg): VCVTrait = {
     val allXrefs = MsgTransformations.popAsArray(rawTrait, "XRef")
-    val (medgenId, xrefs) =
+    val (medgenId, _) =
       allXrefs.foldLeft((Option.empty[String], List.empty[String])) {
         case ((medgenAcc, xrefAcc), xref) =>
           val db = xref.obj.get(Str("@DB")).map(_.str)
@@ -65,7 +63,7 @@ object VCVTrait {
       id = rawTrait.extract("@ID").map(_.str).get,
       medgenTraitId = medgenId,
       name = rawTrait.extract("Name", "ElementValue").flatMap(_.extract("$")).map(_.str),
-      `type` = rawTrait.extract("@Type").map(_.str),
+      `type` = rawTrait.extract("@Type").map(_.str)
     )
   }
 }

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTrait.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTrait.scala
@@ -77,7 +77,7 @@ object VCVTrait {
       },
       medgenTraitId = medgenId,
       name = preferredNameArray.headOption
-        .flatMap(_.extract("ElementValue").get.extract("$").map(_.str)),
+        .flatMap(_.extract("ElementValue", "$").map(_.str)),
       `type` = rawTrait.extract("@Type").map(_.str),
       otherXrefs = otherXrefs.toArray
     )

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTrait.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTrait.scala
@@ -11,8 +11,7 @@ import upack.{Msg, Obj, Str}
   * Info about a trait approved by ClinVar.
   *
   * @param id unique ID of the trait, corresponding to ClinVar's internal TraitID
-  * @param medgenTraitId unique ID of the trait in NCBI's MedGen database,
-  *                      if known
+  * @param medgenTraitId unique ID of the trait in NCBI's MedGen database, if known
   * @param name full name of the trait
   * @param `type` type of the trait
   */

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTraitSet.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTraitSet.scala
@@ -2,10 +2,7 @@ package org.broadinstitute.monster.etl.clinvar.models.output
 
 import io.circe.Encoder
 import io.circe.derivation.{deriveEncoder, renaming}
-import org.broadinstitute.monster.etl.clinvar.models.intermediate.WithContent
 import upack.Msg
-
-import scala.collection.mutable.ArrayBuffer
 
 /**
   * Info about a collection of traits in ClinVar.

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTraitSet.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTraitSet.scala
@@ -5,13 +5,15 @@ import io.circe.derivation.{deriveEncoder, renaming}
 import org.broadinstitute.monster.etl.clinvar.models.intermediate.WithContent
 import upack.Msg
 
+import scala.collection.mutable.ArrayBuffer
+
 /**
   * Info about a collection of traits in ClinVar.
   *
   * @param id unique ID of the trait collection
   * @param `type` common type of the trait collection
   */
-case class VCVTraitSet(id: String, `type`: Option[String], traitIds: Array[String])
+case class VCVTraitSet(id: String, `type`: Option[String], traitIds: ArrayBuffer[String])
 
 object VCVTraitSet {
   import org.broadinstitute.monster.etl.clinvar.MsgOps
@@ -19,11 +21,12 @@ object VCVTraitSet {
   implicit val encoder: Encoder[VCVTraitSet] = deriveEncoder(renaming.snakeCase, None)
 
   /** Extract a TraitSet model from a raw TraitSet payload. */
-  def fromRawSet(rawSet: Msg, vcvTraits: Array[WithContent[VCVTrait]]): VCVTraitSet = VCVTraitSet(
-    id = rawSet.extract("@ID").map(_.str).getOrElse {
-      throw new IllegalStateException(s"Found a VCV Trait Set with no ID: $rawSet")
-    },
-    `type` = rawSet.extract("@Type").map(_.str),
-    traitIds = vcvTraits.map(_.data.id)
-  )
+  def fromRawSet(rawSet: Msg, vcvTraits: ArrayBuffer[WithContent[VCVTrait]]): VCVTraitSet =
+    VCVTraitSet(
+      id = rawSet.extract("@ID").map(_.str).getOrElse {
+        throw new IllegalStateException(s"Found a VCV Trait Set with no ID: $rawSet")
+      },
+      `type` = rawSet.extract("@Type").map(_.str),
+      traitIds = vcvTraits.map(_.data.id)
+    )
 }

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTraitSet.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTraitSet.scala
@@ -5,7 +5,7 @@ import io.circe.derivation.{deriveEncoder, renaming}
 import upack.Msg
 
 /**
-  * Info about a collection of traits included in a submission to ClinVar.
+  * Info about a collection of traits in ClinVar.
   *
   * @param id unique ID of the trait collection
   * @param `type` common type of the trait collection

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTraitSet.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTraitSet.scala
@@ -10,7 +10,7 @@ import upack.Msg
   * @param id unique ID of the trait collection
   * @param `type` common type of the trait collection
   */
-case class VCVTraitSet(id: String, `type`: String)
+case class VCVTraitSet(id: String, `type`: Option[String])
 
 object VCVTraitSet {
   import org.broadinstitute.monster.etl.clinvar.MsgOps
@@ -20,6 +20,6 @@ object VCVTraitSet {
   /** Extract a TraitSet model from a raw TraitSet payload. */
   def fromRawSet(rawSet: Msg): VCVTraitSet = VCVTraitSet(
     id = rawSet.extract("@ID").map(_.str).get,
-    `type` = rawSet.extract("@Type").map(_.str).get
+    `type` = rawSet.extract("@Type").map(_.str)
   )
 }

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTraitSet.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTraitSet.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.monster.etl.clinvar.models.output
 
 import io.circe.Encoder
 import io.circe.derivation.{deriveEncoder, renaming}
-import upack.Msg
+import upack.{Msg, Str}
 
 /**
   * Info about a collection of traits included in a submission to ClinVar.
@@ -13,13 +13,12 @@ import upack.Msg
 case class VCVTraitSet(id: String, `type`: Option[String])
 
 object VCVTraitSet {
-  import org.broadinstitute.monster.etl.clinvar.MsgOps
 
   implicit val encoder: Encoder[VCVTraitSet] = deriveEncoder(renaming.snakeCase, None)
 
   /** Extract a TraitSet model from a raw TraitSet payload. */
   def fromRawSet(rawSet: Msg): VCVTraitSet = VCVTraitSet(
-    id = rawSet.extract("@ID").map(_.str).get,
-    `type` = rawSet.extract("@Type").map(_.str)
+    id = rawSet.obj.get(Str("@ID")).map(_.str).get,
+    `type` = rawSet.obj.get(Str("@Type")).map(_.str)
   )
 }

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTraitSet.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTraitSet.scala
@@ -1,0 +1,43 @@
+package org.broadinstitute.monster.etl.clinvar.models.output
+
+import io.circe.Encoder
+import io.circe.derivation.{deriveEncoder, renaming}
+import upack.Msg
+
+/**
+  * Info about a collection of traits included in a submission to ClinVar.
+  *
+  * @param id unique ID of the trait collection
+  * @param `type` common type of the trait collection
+  */
+case class VCVTraitSet(
+                        id: String,
+                        `type`: Option[String]
+                      )
+
+object VCVTraitSet {
+  import org.broadinstitute.monster.etl.clinvar.MsgOps
+
+  implicit val encoder: Encoder[SCVTraitSet] = deriveEncoder(renaming.snakeCase, None)
+
+  /** Extract a TraitSet model from a raw TraitSet payload which was nested under a ClinicalAssertion. */
+  def fromRawAssertionSet(scv: SCV, rawSet: Msg): SCVTraitSet =
+    fromRawSet(scv.id, Some(scv.id), None, rawSet)
+
+  /** Extract a TraitSet model from a raw TraitSet payload which was nested under observation data. */
+  def fromRawObservationSet(observation: SCVObservation, rawSet: Msg): SCVTraitSet =
+    fromRawSet(observation.id, None, Some(observation.id), rawSet)
+
+  /** Extract a TraitSet model from a raw TraitSet payload. */
+  private def fromRawSet(
+                          id: String,
+                          scvId: Option[String],
+                          observationId: Option[String],
+                          rawSet: Msg
+                        ): SCVTraitSet = SCVTraitSet(
+    id = id,
+    clinicalAssertionId = scvId,
+    clinicalAssertionObservationId = observationId,
+    `type` = rawSet.extract("@Type").map(_.str)
+  )
+}

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTraitSet.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTraitSet.scala
@@ -14,7 +14,7 @@ import scala.collection.mutable.ArrayBuffer
   * @param `type` common type of the trait collection
   * @param traitIds the IDs of the Traits that make up the Trait Set
   */
-case class VCVTraitSet(id: String, `type`: Option[String], traitIds: ArrayBuffer[String])
+case class VCVTraitSet(id: String, `type`: Option[String], traitIds: Array[String])
 
 object VCVTraitSet {
   import org.broadinstitute.monster.etl.clinvar.MsgOps
@@ -24,13 +24,13 @@ object VCVTraitSet {
   /** Extract a TraitSet model from a raw TraitSet payload. */
   def fromRawSet(
     rawSet: Msg,
-    vcvTraits: ArrayBuffer[WithContent[VCVTrait]]
+    vcvTraitIds: Array[String]
   ): VCVTraitSet =
     VCVTraitSet(
       id = rawSet.extract("@ID").map(_.str).getOrElse {
         throw new IllegalStateException(s"Found a VCV Trait Set with no ID: $rawSet")
       },
       `type` = rawSet.extract("@Type").map(_.str),
-      traitIds = vcvTraits.map(_.data.id)
+      traitIds = vcvTraitIds
     )
 }

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTraitSet.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTraitSet.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.monster.etl.clinvar.models.output
 
 import io.circe.Encoder
 import io.circe.derivation.{deriveEncoder, renaming}
+import org.broadinstitute.monster.etl.clinvar.models.intermediate.WithContent
 import upack.Msg
 
 /**
@@ -10,7 +11,7 @@ import upack.Msg
   * @param id unique ID of the trait collection
   * @param `type` common type of the trait collection
   */
-case class VCVTraitSet(id: String, `type`: Option[String])
+case class VCVTraitSet(id: String, `type`: Option[String], traitIds: Array[String])
 
 object VCVTraitSet {
   import org.broadinstitute.monster.etl.clinvar.MsgOps
@@ -18,8 +19,11 @@ object VCVTraitSet {
   implicit val encoder: Encoder[VCVTraitSet] = deriveEncoder(renaming.snakeCase, None)
 
   /** Extract a TraitSet model from a raw TraitSet payload. */
-  def fromRawSet(rawSet: Msg): VCVTraitSet = VCVTraitSet(
-    id = rawSet.extract("@ID").map(_.str).get,
-    `type` = rawSet.extract("@Type").map(_.str)
+  def fromRawSet(rawSet: Msg, vcvTraits: Array[WithContent[VCVTrait]]): VCVTraitSet = VCVTraitSet(
+    id = rawSet.extract("@ID").map(_.str).getOrElse {
+      throw new IllegalStateException(s"Found a VCV Trait Set with no ID: $rawSet")
+    },
+    `type` = rawSet.extract("@Type").map(_.str),
+    traitIds = vcvTraits.map(_.data.id)
   )
 }

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTraitSet.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTraitSet.scala
@@ -12,6 +12,7 @@ import scala.collection.mutable.ArrayBuffer
   *
   * @param id unique ID of the trait collection
   * @param `type` common type of the trait collection
+  * @param traitIds the IDs of the Traits that make up the Trait Set
   */
 case class VCVTraitSet(id: String, `type`: Option[String], traitIds: ArrayBuffer[String])
 
@@ -21,7 +22,10 @@ object VCVTraitSet {
   implicit val encoder: Encoder[VCVTraitSet] = deriveEncoder(renaming.snakeCase, None)
 
   /** Extract a TraitSet model from a raw TraitSet payload. */
-  def fromRawSet(rawSet: Msg, vcvTraits: ArrayBuffer[WithContent[VCVTrait]]): VCVTraitSet =
+  def fromRawSet(
+    rawSet: Msg,
+    vcvTraits: ArrayBuffer[WithContent[VCVTrait]]
+  ): VCVTraitSet =
     VCVTraitSet(
       id = rawSet.extract("@ID").map(_.str).getOrElse {
         throw new IllegalStateException(s"Found a VCV Trait Set with no ID: $rawSet")

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTraitSet.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTraitSet.scala
@@ -10,34 +10,16 @@ import upack.Msg
   * @param id unique ID of the trait collection
   * @param `type` common type of the trait collection
   */
-case class VCVTraitSet(
-                        id: String,
-                        `type`: Option[String]
-                      )
+case class VCVTraitSet(id: String, `type`: String)
 
 object VCVTraitSet {
   import org.broadinstitute.monster.etl.clinvar.MsgOps
 
-  implicit val encoder: Encoder[SCVTraitSet] = deriveEncoder(renaming.snakeCase, None)
-
-  /** Extract a TraitSet model from a raw TraitSet payload which was nested under a ClinicalAssertion. */
-  def fromRawAssertionSet(scv: SCV, rawSet: Msg): SCVTraitSet =
-    fromRawSet(scv.id, Some(scv.id), None, rawSet)
-
-  /** Extract a TraitSet model from a raw TraitSet payload which was nested under observation data. */
-  def fromRawObservationSet(observation: SCVObservation, rawSet: Msg): SCVTraitSet =
-    fromRawSet(observation.id, None, Some(observation.id), rawSet)
+  implicit val encoder: Encoder[VCVTraitSet] = deriveEncoder(renaming.snakeCase, None)
 
   /** Extract a TraitSet model from a raw TraitSet payload. */
-  private def fromRawSet(
-                          id: String,
-                          scvId: Option[String],
-                          observationId: Option[String],
-                          rawSet: Msg
-                        ): SCVTraitSet = SCVTraitSet(
-    id = id,
-    clinicalAssertionId = scvId,
-    clinicalAssertionObservationId = observationId,
-    `type` = rawSet.extract("@Type").map(_.str)
+  def fromRawSet(rawSet: Msg): VCVTraitSet = VCVTraitSet(
+    id = rawSet.extract("@ID").map(_.str).get,
+    `type` = rawSet.extract("@Type").map(_.str).get
   )
 }

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTraitSet.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTraitSet.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.monster.etl.clinvar.models.output
 
 import io.circe.Encoder
 import io.circe.derivation.{deriveEncoder, renaming}
-import upack.{Msg, Str}
+import upack.Msg
 
 /**
   * Info about a collection of traits included in a submission to ClinVar.
@@ -13,12 +13,13 @@ import upack.{Msg, Str}
 case class VCVTraitSet(id: String, `type`: Option[String])
 
 object VCVTraitSet {
+  import org.broadinstitute.monster.etl.clinvar.MsgOps
 
   implicit val encoder: Encoder[VCVTraitSet] = deriveEncoder(renaming.snakeCase, None)
 
   /** Extract a TraitSet model from a raw TraitSet payload. */
   def fromRawSet(rawSet: Msg): VCVTraitSet = VCVTraitSet(
-    id = rawSet.obj.get(Str("@ID")).map(_.str).get,
-    `type` = rawSet.obj.get(Str("@Type")).map(_.str)
+    id = rawSet.extract("@ID").map(_.str).get,
+    `type` = rawSet.extract("@Type").map(_.str)
   )
 }

--- a/common/src/main/scala/org/broadinstitute/monster/etl/MsgTransformations.scala
+++ b/common/src/main/scala/org/broadinstitute/monster/etl/MsgTransformations.scala
@@ -392,8 +392,27 @@ object MsgTransformations {
   )(msg: Msg): Msg =
     mapFieldValues(fields, msg)(parseArray(_, delimiter, parseDouble(_, nanValues)))
 
+  /**
+    * Get the contents of a field in a Msg as an Array and remove the field.
+    *
+    * @param msg the original Msg from which to pull data
+    * @param field the specific field in `msg` to pull data from
+    */
   def popAsArray(msg: Msg, field: String): ArrayBuffer[Msg] =
     msg.obj.remove(Str(field)) match {
+      case None            => ArrayBuffer.empty
+      case Some(Arr(msgs)) => msgs
+      case Some(oneMsg)    => ArrayBuffer(oneMsg)
+    }
+
+  /**
+    * Get the contents of a field in a Msg as an Array without removing the field or contents.
+    *
+    * @param msg the original Msg from which to pull data
+    * @param field the specific field in `msg` to pull data from
+    */
+  def getAsArray(msg: Msg, field: String): ArrayBuffer[Msg] =
+    msg.obj.get(Str(field)) match {
       case None            => ArrayBuffer.empty
       case Some(Arr(msgs)) => msgs
       case Some(oneMsg)    => ArrayBuffer(oneMsg)


### PR DESCRIPTION
Adds code to process and output the VCV Trait and TraitSets (VariationArchiveTrait and VariationArchiveTraitSet tables). This does not link any additional tables. I am not sure if the content is exactly what we want it to be, would appreciate eyes on that as well as on how I pull out the preferred name in VCVTrait.