### PR TITLE
DSPDC-561 Populate TraitMapping table.

### DIFF
--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/ArchiveBranches.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/ArchiveBranches.scala
@@ -27,7 +27,8 @@ case class ArchiveBranches(
   scvTraitSets: SCollection[WithContent[SCVTraitSet]],
   scvTraits: SCollection[WithContent[SCVTrait]],
   vcvTraitSets: SCollection[WithContent[VCVTraitSet]],
-  vcvTraits: SCollection[WithContent[VCVTrait]]
+  vcvTraits: SCollection[WithContent[VCVTrait]],
+  traitMappings: SCollection[TraitMapping]
 )
 
 object ArchiveBranches {
@@ -58,6 +59,7 @@ object ArchiveBranches {
     val scvTraitOut = SideOutput[WithContent[SCVTrait]]
     val vcvTraitSetOut = SideOutput[WithContent[VCVTraitSet]]
     val vcvTraitOut = SideOutput[WithContent[VCVTrait]]
+    val traitMappingOut = SideOutput[TraitMapping]
 
     val (variationStream, sideCtx) = archiveStream
       .withSideOutputs(
@@ -74,7 +76,8 @@ object ArchiveBranches {
         scvTraitSetOut,
         scvTraitOut,
         vcvTraitSetOut,
-        vcvTraitOut
+        vcvTraitOut,
+        traitMappingOut
       )
       .withName("Split Variation Archives")
       .map { (rawArchive, ctx) =>
@@ -98,6 +101,7 @@ object ArchiveBranches {
         parsed.scvTraits.foreach(ctx.output(scvTraitOut, _))
         parsed.vcvTraitSets.foreach(ctx.output(vcvTraitSetOut, _))
         parsed.vcvTraits.foreach(ctx.output(vcvTraitOut, _))
+        parsed.traitMappings.foreach(ctx.output(traitMappingOut, _))
         // Use variation as the main output because each archive contains
         // exactly one of them.
         parsed.variation
@@ -118,7 +122,8 @@ object ArchiveBranches {
       scvTraitSets = sideCtx(scvTraitSetOut),
       scvTraits = sideCtx(scvTraitOut),
       vcvTraitSets = sideCtx(vcvTraitSetOut).distinctBy(_.data.id),
-      vcvTraits = sideCtx(vcvTraitOut).distinctBy(_.data.id)
+      vcvTraits = sideCtx(vcvTraitOut).distinctBy(_.data.id),
+      traitMappings = sideCtx(traitMappingOut)
     )
   }
 }

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/ClinvarPipeline.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/ClinvarPipeline.scala
@@ -113,6 +113,11 @@ object ClinvarPipeline {
       "VCV Traits",
       s"${parsedArgs.outputPrefix}/trait"
     )
+    MsgIO.writeJsonLists(
+      archiveBranches.traitMappings,
+      "Trait Mappings",
+      s"${parsedArgs.outputPrefix}/trait_mapping"
+    )
 
     pipelineContext.run()
     ()

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/SCVTrait.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/SCVTrait.scala
@@ -15,8 +15,7 @@ import upack.{Msg, Obj, Str}
   * @param id unique ID of the trait
   * @param clinicalAssertionTraitSetId unique ID of the collection which
   *                                    includes this trait
-  * @param medgenTraitId unique ID of the trait in NCBI's MedGen database,
-  *                      if known
+  * @param medgenId unique ID of the trait in NCBI's MedGen database, if known
   * @param name full name of the trait
   * @param `type` type of the trait
   * @param xrefs stringified JSON objects describing unique IDs for
@@ -25,7 +24,7 @@ import upack.{Msg, Obj, Str}
 case class SCVTrait(
   id: String,
   clinicalAssertionTraitSetId: String,
-  medgenTraitId: Option[String],
+  medgenId: Option[String],
   name: Option[String],
   `type`: Option[String],
   xrefs: Array[String]
@@ -75,7 +74,7 @@ object SCVTrait {
     SCVTrait(
       id = s"${traitSet.id}.${counter.getAndIncrement()}",
       clinicalAssertionTraitSetId = traitSet.id,
-      medgenTraitId = medgenId,
+      medgenId = medgenId,
       name = nameWrapper.map(_.value.str),
       `type` = rawTrait.extract("@Type").map(_.str),
       xrefs = xrefs.toArray

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/TraitMapping.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/TraitMapping.scala
@@ -1,0 +1,91 @@
+package org.broadinstitute.monster.etl.clinvar.models.output
+
+import io.circe.Encoder
+import io.circe.derivation.{deriveEncoder, renaming}
+import upack.Msg
+
+/**
+  * Info about how "raw" traits included in individual submissions
+  * should map into ClinVar's harmonized trait database.
+  *
+  * @param clinicalAssertionId unique ID of the SCV containing this mapping
+  * @param traitType type of the submitted trait linked to this mapping
+  * @param mappingType category of linking described by this mapping
+  * @param mappingRef type-specific key which should be used to find the SCV
+  *                   trait linked to this mapping
+  * @param mappingValue type-specific value which should be used to find the
+  *                     SCV trait linked to this mapping
+  * @param medgenId unique ID of the SCV trait in NCBI's MedGen database, if known
+  * @param medgenName long name of the SCV trait in NCBI's MedGen database, if known
+  */
+case class TraitMapping(
+  // Fields required for linking mappings to SCV traits.
+  clinicalAssertionId: String, // Also a foreign key.
+  traitType: String,
+  mappingType: String,
+  mappingRef: String,
+  mappingValue: String,
+  // MedGen info.
+  medgenId: Option[String],
+  medgenName: Option[String]
+)
+
+object TraitMapping {
+  import org.broadinstitute.monster.etl.clinvar.MsgOps
+
+  implicit val encoder: Encoder[TraitMapping] = deriveEncoder(renaming.snakeCase, None)
+
+  /** Extract a TraitMapping from a raw TraitMapping payload. */
+  def fromRawMapping(rawMapping: Msg): TraitMapping = {
+    val scvId = rawMapping
+      .extract("@ClinicalAssertionID")
+      .getOrElse {
+        throw new IllegalStateException(
+          s"Found a TraitMapping with no SCV ID: $rawMapping"
+        )
+      }
+      .str
+    val traitType = rawMapping
+      .extract("@TraitType")
+      .getOrElse {
+        throw new IllegalStateException(
+          s"Found a TraitMapping with no trait type: $rawMapping"
+        )
+      }
+      .str
+    val mappingType = rawMapping
+      .extract("@MappingType")
+      .getOrElse {
+        throw new IllegalStateException(
+          s"Found a TraitMapping with no mapping type: $rawMapping"
+        )
+      }
+      .str
+    val mappingKey = rawMapping
+      .extract("@MappingRef")
+      .getOrElse {
+        throw new IllegalStateException(
+          s"Found a TraitMapping with no mapping key: $rawMapping"
+        )
+      }
+      .str
+    val mappingValue = rawMapping
+      .extract("@MappingValue")
+      .getOrElse {
+        throw new IllegalStateException(
+          s"Found a TraitMapping with no mapping value: $rawMapping"
+        )
+      }
+      .str
+
+    TraitMapping(
+      traitType = traitType,
+      mappingType = mappingType,
+      mappingValue = mappingValue,
+      mappingRef = mappingKey,
+      medgenId = rawMapping.extract("MedGen", "@CUI").map(_.str).filter(_ != "None"),
+      medgenName = rawMapping.extract("MedGen", "@Name").map(_.str),
+      clinicalAssertionId = scvId
+    )
+  }
+}

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTrait.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTrait.scala
@@ -11,13 +11,13 @@ import upack.{Msg, Obj, Str}
   * Info about a trait approved by ClinVar.
   *
   * @param id unique ID of the trait, corresponding to ClinVar's internal TraitID
-  * @param medgenTraitId unique ID of the trait in NCBI's MedGen database, if known
+  * @param medgenId unique ID of the trait in NCBI's MedGen database, if known
   * @param name full name of the trait
   * @param `type` type of the trait
   */
 case class VCVTrait(
   id: String,
-  medgenTraitId: Option[String],
+  medgenId: Option[String],
   name: Option[String],
   `type`: Option[String],
   otherXrefs: Array[String]
@@ -75,7 +75,7 @@ object VCVTrait {
       id = rawTrait.extract("@ID").map(_.str).getOrElse {
         throw new IllegalStateException(s"Found a VCV Trait with no ID: $rawTrait")
       },
-      medgenTraitId = medgenId,
+      medgenId = medgenId,
       name = preferredNameArray.headOption
         .flatMap(_.extract("ElementValue").map(_.value.str)),
       `type` = rawTrait.extract("@Type").map(_.str),


### PR DESCRIPTION
I rage-quit the process of trying to invent a PK for the new table. Instead, `trait_mapping` points to `clinical_assertion`, and it uses all of `clinical_assertion`, `trait_type`, `mapping_type`, `mapping_ref`, and `mapping_value` as its compound PK. This should still be enough info to construct the SCV<->VCV trait links.