### PR TITLE
Xref linking dspdc 637

### DIFF
--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/SCVTrait.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/SCVTrait.scala
@@ -74,6 +74,16 @@ object SCVTrait {
       traitId = None
     )
 
+    // Look through the VCVs to see if there are any with aligned medgen IDs
+    val medgenMatches = traits.filter { `trait` =>
+      `trait`.medgenId == baseScv.medgenId
+    }
+
+    // Look through the VCVs to see if there are any with aligned XRefs
+    val xrefMatches = traits.filter { `trait` =>
+      `trait`.xrefs.intersect(baseScv.xrefs).isEmpty
+    }
+
     if (traitMappings.isEmpty) {
       // Lack of trait mappings means the VCV contains at most one trait,
       // which all the attached SCV traits should link to.
@@ -110,23 +120,15 @@ object SCVTrait {
         sameTraitType && (nameMatch || xrefMatch)
       }
 
-      // Look through the VCVs to see if there are any with aligned medgen IDs
-      // TODO
-
-      // Look through the VCVs to see if there are any with aligned XRefs
-      val xrefMatches = traits.filter { `trait` =>
-        `trait`.xrefs.toSet.intersect(baseScv.xrefs.toSet).isEmpty
-      }
-
       // Find the MedGen ID / name to look for in the VCV traits.
       val matchingMedgenId = matchingMapping.flatMap(_.medgenId)
       val matchingName = matchingMapping.flatMap(_.medgenName)
       // Find the VCV trait with the matching MedGen ID if it's defined.
       // Otherwise match on preferred name.
-      val matchingVcvTrait = traits
-        .find(_.medgenId == matchingMedgenId)
-        .orElse(traits.find(_.name == matchingName))
+      val matchingVcvTrait = medgenMatches.headOption
         .orElse(xrefMatches.headOption)
+        .orElse(traits.find(_.medgenId == matchingMedgenId))
+        .orElse(traits.find(_.name == matchingName))
 
       // Link! Fill in the MegGen ID of the mapping too, if the SCV trait
       // didn't already contain one.

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/SCVTrait.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/SCVTrait.scala
@@ -76,7 +76,7 @@ object SCVTrait {
     val medgenDirectMatch = traits.find(_.medgenId == baseScv.medgenId)
 
     // Look through the VCVs to see if there are any with aligned XRefs
-    val xrefDirectMatch = traits.find(_.xrefs.intersect(baseScv.xrefs).isEmpty)
+    val xrefDirectMatch = traits.find(!_.xrefs.intersect(baseScv.xrefs).isEmpty)
 
     if (traitMappings.isEmpty) {
       // Lack of trait mappings means the VCV contains at most one trait,

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/SCVTrait.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/SCVTrait.scala
@@ -75,12 +75,12 @@ object SCVTrait {
     )
 
     // Look through the VCVs to see if there are any with aligned medgen IDs
-    val medgenMatches = traits.filter { `trait` =>
+    val medgenDirectMatches = traits.filter { `trait` =>
       `trait`.medgenId == baseScv.medgenId
     }
 
     // Look through the VCVs to see if there are any with aligned XRefs
-    val xrefMatches = traits.filter { `trait` =>
+    val xrefDirectMatches = traits.filter { `trait` =>
       `trait`.xrefs.intersect(baseScv.xrefs).isEmpty
     }
 
@@ -125,8 +125,8 @@ object SCVTrait {
       val matchingName = matchingMapping.flatMap(_.medgenName)
       // Find the VCV trait with the matching MedGen ID if it's defined.
       // Otherwise match on preferred name.
-      val matchingVcvTrait = medgenMatches.headOption
-        .orElse(xrefMatches.headOption)
+      val matchingVcvTrait = medgenDirectMatches.headOption
+        .orElse(xrefDirectMatches.headOption)
         .orElse(traits.find(_.medgenId == matchingMedgenId))
         .orElse(traits.find(_.name == matchingName))
 

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/SCVTrait.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/SCVTrait.scala
@@ -110,23 +110,23 @@ object SCVTrait {
         sameTraitType && (nameMatch || xrefMatch)
       }
 
-      // Look through the VCVs to see if there are any with aligned XRefs?
+      // Look through the VCVs to see if there are any with aligned medgen IDs
       // TODO
-//      traits.foreach { t =>
-//        val temp = t.xrefs.toSet.intersect(baseScv.xrefs.toSet)
-//        println("FALAFEL")
-//        println(temp)
-//      }
+
+      // Look through the VCVs to see if there are any with aligned XRefs
+      val xrefMatches = traits.filter { `trait` =>
+        `trait`.xrefs.toSet.intersect(baseScv.xrefs.toSet).isEmpty
+      }
 
       // Find the MedGen ID / name to look for in the VCV traits.
       val matchingMedgenId = matchingMapping.flatMap(_.medgenId)
       val matchingName = matchingMapping.flatMap(_.medgenName)
       // Find the VCV trait with the matching MedGen ID if it's defined.
       // Otherwise match on preferred name.
-
       val matchingVcvTrait = traits
         .find(_.medgenId == matchingMedgenId)
         .orElse(traits.find(_.name == matchingName))
+        .orElse(xrefMatches.headOption)
 
       // Link! Fill in the MegGen ID of the mapping too, if the SCV trait
       // didn't already contain one.

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/SCVTrait.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/SCVTrait.scala
@@ -45,9 +45,7 @@ object SCVTrait {
     val nameWrapper = rawTrait.extract("Name", "ElementValue")
     val nameType = nameWrapper.flatMap(_.extract("@Type")).map(_.str)
 
-    val allXrefs = MsgTransformations.popAsArray(rawTrait, "XRef").map { xref =>
-      XRef.fromRawXRef(xref)
-    }
+    val allXrefs = MsgTransformations.popAsArray(rawTrait, "XRef").map(XRef.fromRawXRef)
     val (medgenId, xrefs) =
       allXrefs.foldLeft((Option.empty[String], List.empty[XRef])) {
         case ((medgenAcc, xrefAcc), xref) =>
@@ -75,14 +73,10 @@ object SCVTrait {
     )
 
     // Look through the VCVs to see if there are any with aligned medgen IDs
-    val medgenDirectMatches = traits.filter { `trait` =>
-      `trait`.medgenId == baseScv.medgenId
-    }
+    val medgenDirectMatch = traits.find(_.medgenId == baseScv.medgenId)
 
     // Look through the VCVs to see if there are any with aligned XRefs
-    val xrefDirectMatches = traits.filter { `trait` =>
-      `trait`.xrefs.intersect(baseScv.xrefs).isEmpty
-    }
+    val xrefDirectMatch = traits.find(_.xrefs.intersect(baseScv.xrefs).isEmpty)
 
     if (traitMappings.isEmpty) {
       // Lack of trait mappings means the VCV contains at most one trait,
@@ -125,8 +119,8 @@ object SCVTrait {
       val matchingName = matchingMapping.flatMap(_.medgenName)
       // Find the VCV trait with the matching MedGen ID if it's defined.
       // Otherwise match on preferred name.
-      val matchingVcvTrait = medgenDirectMatches.headOption
-        .orElse(xrefDirectMatches.headOption)
+      val matchingVcvTrait = medgenDirectMatch
+        .orElse(xrefDirectMatch)
         .orElse(traits.find(_.medgenId == matchingMedgenId))
         .orElse(traits.find(_.name == matchingName))
 

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTrait.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTrait.scala
@@ -24,7 +24,7 @@ case class VCVTrait(
   name: Option[String],
   alternateNames: Array[String],
   `type`: Option[String],
-  xrefs: Array[String]
+  xrefs: Array[XRef]
 )
 
 object VCVTrait {
@@ -38,7 +38,7 @@ object VCVTrait {
     val allNames = MsgTransformations.popAsArray(rawTrait, "Name")
 
     val (preferredName, alternateNames, nameXrefs) =
-      allNames.foldLeft((Option.empty[String], List.empty[String], List.empty[String])) {
+      allNames.foldLeft((Option.empty[String], List.empty[String], List.empty[XRef])) {
         case ((prefAcc, altAcc, xrefAcc), name) =>
           val nameValue = name.extract("ElementValue").getOrElse {
             throw new IllegalStateException(s"Found a name with no value: $name")
@@ -53,11 +53,7 @@ object VCVTrait {
 
           val nameRefs = MsgTransformations
             .popAsArray(name, "XRef")
-            .map { nameRef =>
-              // Tag the ref with its source name so we can rebuild associations.
-              nameRef.obj.update(Str("name"), nameString)
-              processXref(nameRef)
-            }
+            .map { nameRef => XRef.fromRawXRef(nameRef) }
             .toList
 
           if (nameType == "Preferred") {
@@ -73,23 +69,20 @@ object VCVTrait {
           }
       }
 
-    val topLevelRefs = MsgTransformations.popAsArray(rawTrait, "XRef")
+    val topLevelRefs = MsgTransformations.popAsArray(rawTrait, "XRef").map {xref => XRef.fromRawXRef(xref)}
     val (medgenId, finalXrefs) =
       topLevelRefs.foldLeft((Option.empty[String], nameXrefs)) {
         case ((medgenAcc, xrefAcc), xref) =>
-          val db = xref.obj.get(Str("@DB")).map(_.str)
-          val id = xref.obj.get(Str("@ID")).map(_.str)
-
-          if (db.contains(ClinvarConstants.MedGenKey)) {
+          if (xref.db.contains(ClinvarConstants.MedGenKey)) {
             if (medgenAcc.isDefined) {
               throw new IllegalStateException(
                 s"VCV Trait Set contains two MedGen references: $rawTrait"
               )
             } else {
-              (id, xrefAcc)
+              (Option(xref.id), xrefAcc)
             }
           } else {
-            (medgenAcc, processXref(xref) :: xrefAcc)
+            (medgenAcc, xref :: xrefAcc)
           }
       }
 
@@ -103,20 +96,5 @@ object VCVTrait {
       `type` = rawTrait.extract("@Type").map(_.str),
       xrefs = finalXrefs.toArray
     )
-  }
-
-  /**
-    * Convert the keys of an XRef object to BQ-safe-snake-case, and stringify
-    * it for storage in an array column.
-    */
-  def processXref(xref: Msg): String = {
-    val cleaned = Obj()
-    xref.obj.foreach {
-      case (k, v) =>
-        val cleanedKey =
-          MsgTransformations.keyToSnakeCase(k.str.replaceAllLiterally("@", ""))
-        cleaned.obj.update(Str(cleanedKey), v)
-    }
-    upack.transform(cleaned, StringRenderer()).toString
   }
 }

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTrait.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTrait.scala
@@ -94,7 +94,7 @@ object VCVTrait {
       name = preferredName,
       alternateNames = alternateNames.toArray,
       `type` = rawTrait.extract("@Type").map(_.str),
-      xrefs = finalXrefs.toArray
+      xrefs = finalXrefs.toArray.distinct
     )
   }
 }

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTrait.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/VCVTrait.scala
@@ -4,8 +4,7 @@ import io.circe.Encoder
 import io.circe.derivation.{deriveEncoder, renaming}
 import org.broadinstitute.monster.etl.MsgTransformations
 import org.broadinstitute.monster.etl.clinvar.ClinvarConstants
-import ujson.StringRenderer
-import upack.{Msg, Obj, Str}
+import upack.Msg
 
 /**
   * Info about a trait approved by ClinVar.
@@ -53,7 +52,9 @@ object VCVTrait {
 
           val nameRefs = MsgTransformations
             .popAsArray(name, "XRef")
-            .map { nameRef => XRef.fromRawXRef(nameRef) }
+            .map { nameRef =>
+              XRef.fromRawXRef(nameRef)
+            }
             .toList
 
           if (nameType == "Preferred") {
@@ -69,7 +70,9 @@ object VCVTrait {
           }
       }
 
-    val topLevelRefs = MsgTransformations.popAsArray(rawTrait, "XRef").map {xref => XRef.fromRawXRef(xref)}
+    val topLevelRefs = MsgTransformations.popAsArray(rawTrait, "XRef").map { xref =>
+      XRef.fromRawXRef(xref)
+    }
     val (medgenId, finalXrefs) =
       topLevelRefs.foldLeft((Option.empty[String], nameXrefs)) {
         case ((medgenAcc, xrefAcc), xref) =>

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/XRef.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/XRef.scala
@@ -14,14 +14,18 @@ object XRef {
 
   def fromRawXRef(rawXref: Msg): XRef = {
     XRef(
-      rawXref.obj.getOrElse(
-        Str("@DB"),
-        throw new IllegalStateException(s"No DB tag found in xref: $rawXref")
-      ).toString,
-      rawXref.obj.getOrElse(
-        Str("@ID"),
-        throw new IllegalStateException(s"No ID tag found in xref: $rawXref")
-      ).toString
+      rawXref.obj
+        .getOrElse(
+          Str("@DB"),
+          throw new IllegalStateException(s"No DB tag found in xref: $rawXref")
+        )
+        .toString,
+      rawXref.obj
+        .getOrElse(
+          Str("@ID"),
+          throw new IllegalStateException(s"No ID tag found in xref: $rawXref")
+        )
+        .toString
     )
   }
 }

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/XRef.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/XRef.scala
@@ -1,0 +1,13 @@
+package org.broadinstitute.monster.etl.clinvar.models.output
+
+import io.circe.{Encoder, Json}
+import io.circe.derivation.deriveEncoder
+
+case class XRef(db: String, id: String)
+
+object XRef {
+
+  // Jade doesn't support struct columns yet, so we output these as stringified JSONs.
+  implicit val encoder: Encoder[XRef] =
+    deriveEncoder.mapJson(obj => Json.fromString(obj.noSpaces))
+}

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/XRef.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/XRef.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.monster.etl.clinvar.models.output
 
 import io.circe.{Encoder, Json}
 import io.circe.derivation.deriveEncoder
+import upack.{Msg, Str}
 
 case class XRef(db: String, id: String)
 
@@ -10,4 +11,17 @@ object XRef {
   // Jade doesn't support struct columns yet, so we output these as stringified JSONs.
   implicit val encoder: Encoder[XRef] =
     deriveEncoder.mapJson(obj => Json.fromString(obj.noSpaces))
+
+  def fromRawXRef(rawXref: Msg): XRef = {
+    XRef(
+      rawXref.obj.getOrElse(
+        Str("@DB"),
+        throw new IllegalStateException(s"No DB tag found in xref: $rawXref")
+      ).toString,
+      rawXref.obj.getOrElse(
+        Str("@ID"),
+        throw new IllegalStateException(s"No ID tag found in xref: $rawXref")
+      ).toString
+    )
+  }
 }

--- a/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/XRef.scala
+++ b/clinvar/src/main/scala/org/broadinstitute/monster/etl/clinvar/models/output/XRef.scala
@@ -19,13 +19,13 @@ object XRef {
           Str("@DB"),
           throw new IllegalStateException(s"No DB tag found in xref: $rawXref")
         )
-        .toString,
+        .str,
       rawXref.obj
         .getOrElse(
           Str("@ID"),
           throw new IllegalStateException(s"No ID tag found in xref: $rawXref")
         )
-        .toString
+        .str
     )
   }
 }


### PR DESCRIPTION
Adds XRef class, updates SCVTrait and VCVTrait to use said class, update SCV <-> VCV trait linking to try direct medgen ID matching, then any direct XRef matching, and _then_ the existing code that uses the trait mapping piece to try to link them.